### PR TITLE
fix undefined variable in podcast.js

### DIFF
--- a/lib/podcast.js
+++ b/lib/podcast.js
@@ -91,7 +91,7 @@ function Podcast (options, items) {
     });
 
     this.xml = function(indent) {
-      rss = new RSS(this, this.items);
+      var rss = new RSS(this, this.items);
       return rss.xml(indent);
     }
 }


### PR DESCRIPTION
I know a pull request ouf of nowhere can be weird. It's just that your package is exactly what my project needed, it's too bad this missing `var` is making everything crash on nodejs v5.x.x.

Keep up the good work! :smile: 