### PR TITLE
Only the last item in itunesKeywords is included in RSS.

### DIFF
--- a/lib/podcast.js
+++ b/lib/podcast.js
@@ -75,7 +75,7 @@ function Podcast (options, items) {
         if(options.itunesSummary || options.description) item.custom_elements.push({'itunes:summary':   options.itunesSummary || options.description});
         item.custom_elements.push({'itunes:explicit':  (options.itunesExplicit || false) ? 'Yes' : 'No'});
         if(options.itunesDuration) item.custom_elements.push({'itunes:duration':  options.itunesDuration});
-        if(options.itunesKeywords) item.custom_elements.push({'itunes:keywords':  options.itunesKeywords.join(',')});
+        if(options.itunesKeywords) item.custom_elements.push({'itunes:keywords':  [options.itunesKeywords.join(',')]});
         if(options.itunesImage || options.image_url) item.custom_elements.push({'itunes:image': {
           _attr: {
             href: options.itunesImage || options.image_url

--- a/lib/podcast.js
+++ b/lib/podcast.js
@@ -75,7 +75,7 @@ function Podcast (options, items) {
         if(options.itunesSummary || options.description) item.custom_elements.push({'itunes:summary':   options.itunesSummary || options.description});
         item.custom_elements.push({'itunes:explicit':  (options.itunesExplicit || false) ? 'Yes' : 'No'});
         if(options.itunesDuration) item.custom_elements.push({'itunes:duration':  options.itunesDuration});
-        if(options.itunesKeywords) item.custom_elements.push({'itunes:keywords':  options.itunesKeywords});
+        if(options.itunesKeywords) item.custom_elements.push({'itunes:keywords':  options.itunesKeywords.join(',')});
         if(options.itunesImage || options.image_url) item.custom_elements.push({'itunes:image': {
           _attr: {
             href: options.itunesImage || options.image_url


### PR DESCRIPTION
If you specify more than one keyword in itunesKeywords option, only the last keyword in the Array is included in RSS.
So I changed the code so that all the keywords are included, separated by commas.
https://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html#_Toc526931686