### PR TITLE
Use the master branch's build status

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Podcast RSS for Node [![Build Status](https://travis-ci.org/maxnowack/node-podcast.svg)](https://travis-ci.org/maxnowack/node-podcast)
+# Podcast RSS for Node [![Build Status](https://travis-ci.org/maxnowack/node-podcast.svg?branch=master)](https://travis-ci.org/maxnowack/node-podcast)
 
 > Fast and simple Podcast RSS generator/builder for Node projects. Supports enclosures and GeoRSS.
 


### PR DESCRIPTION
This will make the readme badge green, like it should be, since the build is passing.