### PR TITLE
Adding support for custom XML elements

### DIFF
--- a/lib/podcast.js
+++ b/lib/podcast.js
@@ -23,14 +23,13 @@ function Podcast (options, items) {
     this.webMaster      = options.webMaster;
     this.ttl            = options.ttl;
     this.geoRSS         = options.geoRSS || false;
+    this.custom_elements = options.customElements || [];
 
     this.custom_namespaces = {
       'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'
     };
 
     options.itunesOwner = options.itunesOwner || {"name":options.author || "","email":""};
-
-    this.custom_elements = [];
 
     if(options.itunesAuthor || options.author) this.custom_elements.push({'itunes:author':    options.itunesAuthor || options.author});
     if(options.itunesSubtitle) this.custom_elements.push({'itunes:subtitle':  options.itunesSubtitle});
@@ -67,7 +66,7 @@ function Podcast (options, items) {
             lat:            options.lat,
             long:           options.long,
             enclosure:      options.enclosure || false,
-            custom_elements: []
+            custom_elements: options.customElements || []
         };
 
         if(options.itunesAuthor || options.author) item.custom_elements.push({'itunes:author':    options.itunesAuthor || options.author});

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ var feed = new Podcast(feedOptions);
  * `itunesExplicit` _optional_ **boolean** (iTunes specific) specifies if the podcast contains explicit content
  * `itunesCategory` _optional_ **array of objects** (iTunes specific) Categories for iTunes ( [{text:String, subcats:[{text:String, subcats:Array}]}] )
  * `itunesImage` _optional_ **string** (iTunes specific) link to an image for the podcast
+ * `customElements`: _optional_ **array of objects** Add any custom tag ( [{yourCustomAttribute: yourCustomValue}] )
 
 ### Add items to a feed
 
@@ -82,6 +83,7 @@ feed.item(itemOptions);
  * `itunesDuration` _optional_ **number** (iTunes specific) duration of the podcast item in seconds
  * `itunesKeywords` _optional_ **array of string** (iTunes specific) keywords of the podcast
  * `itunesImage` _optional_ **string** (iTunes specific) link to an image for the item
+ * `customElements`: _optional_ **array of objects** Add any custom tag ( [{yourCustomAttribute: yourCustomValue}] )
 
 #### Feed XML
 


### PR DESCRIPTION
Users can now pass an array of objects as `options.customElements` -- Apple [recently added new items to its RSS spec](http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf), and instead of hard coding new values as they get added, I thought it would be helpful to let people add arbitrary XML tags. This PR adds both the code and the documentation for the feature.