### PR TITLE
Adding new iTunes tags per iOS11 spec

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ const feed = new Podcast(feedOptions);
  * `itunesExplicit` _optional_ **boolean** (iTunes specific) specifies if the podcast contains explicit content
  * `itunesCategory` _optional_ **array of objects** (iTunes specific) Categories for iTunes ( [{text:String, subcats:[{text:String, subcats:Array}]}] )
  * `itunesImage` _optional_ **string** (iTunes specific) link to an image for the podcast
+ * `itunesType` _optional_ **string** (iTunes specific) type of podcast (`episodic` or `serial`)
  * `customNamespaces` _optional_ **object** Put additional namespaces in <rss> element (without 'xmlns:' prefix)
  * `customElements` _optional_ **array** Put additional elements in the feed (node-xml syntax)
 
@@ -84,6 +85,10 @@ feed.addItem(itemOptions);
  * `itunesDuration` _optional_ **number** (iTunes specific) duration of the podcast item in seconds
  * `itunesKeywords` _optional_ **array of strings** (iTunes specific) keywords of the podcast
  * `itunesImage` _optional_ **string** (iTunes specific) link to an image for the item
+ * `itunesSeason` _optional_ **number** (iTunes specific) season number (non-zero integer)
+ * `itunesEpisode` _optional_ **number** (iTunes specific) episode number (non-zero integer)
+ * `itunesTitle` _optional_ **string** (iTunes specific) episode title
+ * `itunesEpisodeType` _optional_ **string** (iTunes specific) the type of episode (`full` (default), `trailer`, `bonus`)
  * `customElements` _optional_ **array** Put additional elements in the item (node-xml syntax)
 
 #### Feed XML

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,8 @@ export default class Podcast {
       this.feedOptions.custom_elements.push({ 'itunes:summary': options.itunesSummary || options.description });
     }
 
-    if(options.itunesType) {
-      this.custom_elements.push({'itunes:type':  options.itunesType});
+    if (options.itunesType) {
+      this.feedOptions.custom_elements.push({ 'itunes:type': options.itunesType });
     }
 
     this.feedOptions.itunesOwner = options.itunesOwner || { name: options.author || '', email: '' };
@@ -109,10 +109,10 @@ export default class Podcast {
         },
       });
     }
-    if(options.itunesSeason) item.custom_elements.push({'itunes:season':  options.itunesSeason});
-    if(options.itunesEpisode) item.custom_elements.push({'itunes:episode':  options.itunesEpisode});
-    if(options.itunesTitle) item.custom_elements.push({'itunes:title':  options.itunesTitle});
-    if(options.itunesEpisodeType) item.custom_elements.push({'itunes:episodeType':  options.itunesEpisodeType});
+    if (itemOptions.itunesSeason) item.custom_elements.push({ 'itunes:season': itemOptions.itunesSeason });
+    if (itemOptions.itunesEpisode) item.custom_elements.push({ 'itunes:episode': itemOptions.itunesEpisode });
+    if (itemOptions.itunesTitle) item.custom_elements.push({ 'itunes:title': itemOptions.itunesTitle });
+    if (itemOptions.itunesEpisodeType) item.custom_elements.push({ 'itunes:episodeType': itemOptions.itunesEpisodeType });
 
     this.items.push(item);
     return this;

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,10 @@ export default class Podcast {
       this.feedOptions.custom_elements.push({ 'itunes:summary': options.itunesSummary || options.description });
     }
 
+    if(options.itunesType) {
+      this.custom_elements.push({'itunes:type':  options.itunesType});
+    }
+
     this.feedOptions.itunesOwner = options.itunesOwner || { name: options.author || '', email: '' };
     this.feedOptions.custom_elements.push({
       'itunes:owner': [
@@ -105,6 +109,10 @@ export default class Podcast {
         },
       });
     }
+    if(options.itunesSeason) item.custom_elements.push({'itunes:season':  options.itunesSeason});
+    if(options.itunesEpisode) item.custom_elements.push({'itunes:episode':  options.itunesEpisode});
+    if(options.itunesTitle) item.custom_elements.push({'itunes:title':  options.itunesTitle});
+    if(options.itunesEpisodeType) item.custom_elements.push({'itunes:episodeType':  options.itunesEpisodeType});
 
     this.items.push(item);
     return this;

--- a/test/expectedOutput/podcast.xml
+++ b/test/expectedOutput/podcast.xml
@@ -13,6 +13,7 @@
     <itunes:author>John Doe</itunes:author>
     <itunes:subtitle>A show about everything</itunes:subtitle>
     <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</itunes:summary>
+    <itunes:type>episodic</itunes:type>
     <itunes:owner>
       <itunes:name>John Doe</itunes:name>
       <itunes:email>john.doe@example.com</itunes:email>
@@ -37,6 +38,10 @@
       <itunes:explicit>No</itunes:explicit>
       <itunes:duration>7:04</itunes:duration>
       <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg"/>
+      <itunes:season>1</itunes:season>
+      <itunes:episode>1</itunes:episode>
+      <itunes:title>itunes item 1</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
     </item>
   </channel>
 </rss>

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,7 @@ test('podcast', (t) => {
       email: 'john.doe@example.com',
     },
     itunesImage: 'http://example.com/podcasts/everything/AllAboutEverything.jpg',
+    itunesType: 'episodic',
     itunesCategory: [{
       text: 'Technology',
       subcats: [{
@@ -53,6 +54,10 @@ test('podcast', (t) => {
     itunesSubtitle: 'A short primer on table spices',
     itunesImage: 'http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg',
     itunesDuration: '7:04',
+    itunesEpisode: 1,
+    itunesSeason: 1,
+    itunesTitle: 'itunes item 1',
+    itunesEpisodeType: 'full',
   });
 
   t.is(feed.buildXml({ indent: '  ' }), expectedOutput.podcast.trim());


### PR DESCRIPTION
Per discussion in #17, this commit hard codes the new iTunes tags [defined in the iOS11 RSS spec update](http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf).