### PR TITLE
Add <itunes:new-feed-url> tag  using itunesNewFeedUrl

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ feed.addItem(itemOptions);
  * `itunesEpisode` _optional_ **number** (iTunes specific) episode number (non-zero integer)
  * `itunesTitle` _optional_ **string** (iTunes specific) episode title
  * `itunesEpisodeType` _optional_ **string** (iTunes specific) the type of episode (`full` (default), `trailer`, `bonus`)
+ * `itunesNewFeedUrl` _optional_ **string** (iTunes specific) The new podcast RSS Feed URL.
  * `customElements` _optional_ **array** Put additional elements in the item (node-xml syntax)
 
 #### Feed XML
@@ -155,7 +156,8 @@ feed.addItem({
     itunesSubtitle: 'I am a sub title',
     itunesSummary: 'I am a summary',
     itunesDuration: 12345,
-    itunesKeywords: ['javascript','podcast']
+    itunesKeywords: ['javascript','podcast'],
+    itunesNewFeedUrl: 'https://newlocation.com/example.rss',
 });
 
 // cache the xml to send to clients

--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,8 @@ export default class Podcast {
     if (itemOptions.itunesEpisode) item.custom_elements.push({ 'itunes:episode': itemOptions.itunesEpisode });
     if (itemOptions.itunesTitle) item.custom_elements.push({ 'itunes:title': itemOptions.itunesTitle });
     if (itemOptions.itunesEpisodeType) item.custom_elements.push({ 'itunes:episodeType': itemOptions.itunesEpisodeType });
+    if (itemOptions.itunesNewFeedUrl) item.custom_elements.push({ 'itunes:new-feed-url': itemOptions.itunesNewFeedUrl });
+
 
     this.items.push(item);
     return this;

--- a/test/expectedOutput/podcast.xml
+++ b/test/expectedOutput/podcast.xml
@@ -42,6 +42,7 @@
       <itunes:episode>1</itunes:episode>
       <itunes:title>itunes item 1</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
+      <itunes:new-feed-url>https://newlocation.com/example.rss</itunes:new-feed-url>
     </item>
   </channel>
 </rss>

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,7 @@ test('podcast', (t) => {
     itunesSeason: 1,
     itunesTitle: 'itunes item 1',
     itunesEpisodeType: 'full',
+    itunesNewFeedUrl: 'https://newlocation.com/example.rss',
   });
 
   t.is(feed.buildXml({ indent: '  ' }), expectedOutput.podcast.trim());


### PR DESCRIPTION
<itunes:new-feed-url> is useful when redirecting a podcast to a new location.
ref here: https://help.apple.com/itc/podcasts_connect/#/itcb54353390