### PR TITLE
Omit owner tag if not included in args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,7 @@ export class Podcast {
       },
     };
 
-    options.itunesOwner = options.itunesOwner || {
-      name: options.author || "",
-      email: "",
-    };
+    options.itunesOwner = options.itunesOwner;
 
     options.namespaces = options.namespaces || {};
 
@@ -105,15 +102,20 @@ export class Podcast {
       });
     }
 
-    customElements.push({
-      "itunes:owner": [
-        { "itunes:name": options.itunesOwner?.name || "" },
-        { "itunes:email": options.itunesOwner?.email || "" },
-      ],
-    });
+    if (options.itunesOwner) {
+      customElements.push({
+        "itunes:owner": [
+          { "itunes:name": options.itunesOwner?.name || "" },
+          { "itunes:email": options.itunesOwner?.email || "" },
+        ],
+      });
+    }
 
     customElements.push({
-      "itunes:explicit": typeof options.itunesExplicit === "boolean" ? !!options.itunesExplicit : options.itunesExplicit || false,
+      "itunes:explicit":
+        typeof options.itunesExplicit === "boolean"
+          ? !!options.itunesExplicit
+          : options.itunesExplicit || false,
     });
 
     if (options.itunesCategory) {
@@ -178,7 +180,10 @@ export class Podcast {
       });
     }
     customElements.push({
-      "itunes:explicit": typeof itemOptions.itunesExplicit === "boolean" ? !!itemOptions.itunesExplicit : itemOptions.itunesExplicit || false,
+      "itunes:explicit":
+        typeof itemOptions.itunesExplicit === "boolean"
+          ? !!itemOptions.itunesExplicit
+          : itemOptions.itunesExplicit || false,
     });
     if (itemOptions.itunesDuration) {
       customElements.push({

--- a/test/expectedOutput/itunes/podcastMinusOwner.xml
+++ b/test/expectedOutput/itunes/podcastMinusOwner.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title><![CDATA[title]]></title>
+    <description><![CDATA[description]]></description>
+    <link>http://example.com</link>
+    <generator>Podcast for Node</generator>
+    <lastBuildDate>Wed, 10 Dec 2014 19:04:57 GMT</lastBuildDate>
+    <atom:link href="http://example.com/rss.xml" rel="self" type="application/rss+xml"/>
+    <author><![CDATA[Dylan Greene]]></author>
+    <pubDate>Sun, 20 May 2012 04:00:00 GMT</pubDate>
+    <language><![CDATA[en]]></language>
+    <ttl>60</ttl>
+    <itunes:author>John Doe</itunes:author>
+    <itunes:subtitle>A show about everything</itunes:subtitle>
+    <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</itunes:summary>
+    <itunes:type>episodic</itunes:type>
+    <itunes:explicit>false</itunes:explicit>
+    <itunes:category text="Technology">
+      <itunes:category text="Software">
+        <itunes:category text="node.js"/>
+      </itunes:category>
+    </itunes:category>
+    <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything.jpg"/>
+    <item>
+      <title><![CDATA[item 1]]></title>
+      <description><![CDATA[description 1]]></description>
+      <link>http://example.com/article1</link>
+      <guid isPermaLink="true">http://example.com/article1</guid>
+      <dc:creator><![CDATA[Dylan Greene]]></dc:creator>
+      <pubDate>Thu, 24 May 2012 04:00:00 GMT</pubDate>
+      <itunes:author>John Doe</itunes:author>
+      <itunes:subtitle>A short primer on table spices</itunes:subtitle>
+      <itunes:summary>description 1</itunes:summary>
+      <itunes:explicit>false</itunes:explicit>
+      <itunes:duration>00:07:04</itunes:duration>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg"/>
+      <itunes:season>1</itunes:season>
+      <itunes:episode>1</itunes:episode>
+      <itunes:title>itunes item 1</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  </channel>
+</rss>

--- a/test/itunes.ts
+++ b/test/itunes.ts
@@ -76,6 +76,64 @@ test("podcast", (t) => {
 
   t.is(feed.buildXml({ indent: "  " }), expectedOutput.podcast.trim());
 });
+
+test("podcastMinusOwner", (t) => {
+  const feed = new Podcast({
+    namespaces,
+    title: "title",
+    description: "description",
+    feedUrl: "http://example.com/rss.xml",
+    siteUrl: "http://example.com",
+    author: "Dylan Greene",
+    pubDate: "May 20, 2012 04:00:00 GMT",
+    language: "en",
+    ttl: 60,
+    itunesSubtitle: "A show about everything",
+    itunesAuthor: "John Doe",
+    itunesSummary:
+      "All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store",
+    itunesImage:
+      "http://example.com/podcasts/everything/AllAboutEverything.jpg",
+    itunesType: "episodic",
+    itunesCategory: [
+      {
+        text: "Technology",
+        subcats: [
+          {
+            text: "Software",
+            subcats: [
+              {
+                text: "node.js",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  feed.addItem({
+    title: "item 1",
+    description: "description 1",
+    url: "http://example.com/article1",
+    date: "May 24, 2012 04:00:00 GMT",
+    itunesAuthor: "John Doe",
+    itunesSubtitle: "A short primer on table spices",
+    itunesImage:
+      "http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg",
+    itunesDuration: 424,
+    itunesEpisode: 1,
+    itunesSeason: 1,
+    itunesTitle: "itunes item 1",
+    itunesEpisodeType: "full",
+  });
+
+  t.is(
+    feed.buildXml({ indent: "  " }),
+    expectedOutput.podcastMinusOwner.trim()
+  );
+});
+
 test("podcast with new feed url", (t) => {
   const feed = new Podcast({
     namespaces,


### PR DESCRIPTION
Proposed fix for #56 

- Change logic so `itunesOwner` element is pushed to feed array only if an explicit value exists
- Add test for omitted `owner` tag